### PR TITLE
fix: require npm 11 for workspace installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A multi-app monorepo containing a React Native mobile app and a Vite + React web
 ---
 
 ## Prerequisites
-- Node.js >= 18, npm 10 (repo sets `packageManager: npm@10`)
+- Node.js >= 18, npm 11 (repo sets `packageManager: npm@11.4.2`)
 - macOS for iOS development: Xcode + Command Line Tools
 - Android development: Android Studio + SDKs, device/emulator
 - Ruby for CocoaPods (mobile iOS)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
       "typecheck": "tsc -b"
     },
     "license": "MIT",
-    "packageManager": "npm@10"
+    "packageManager": "npm@11.4.2"
   }
   


### PR DESCRIPTION
## Summary
- specify npm 11.4.2 in package.json to ensure workspace protocol support
- document new npm requirement in README

## Testing
- `npm install`
- `npm --workspace apps/mobile test` *(passes)*
- `npm run web:test` *(fails: No workspaces found --workspace=web)*
- `npm --workspace apps/web test` *(fails: Invalid hook call)*

------
https://chatgpt.com/codex/tasks/task_e_6899fab06450832c9d5181e61c6cd33d