### PR TITLE
feat: add basic React Native home screen

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -5,8 +5,8 @@
  * @format
  */
 
-import { NewAppScreen } from '@react-native/new-app-screen';
 import { StatusBar, StyleSheet, useColorScheme, View } from 'react-native';
+import HomeScreen from './screens/HomeScreen';
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
@@ -14,7 +14,7 @@ function App() {
   return (
     <View style={styles.container}>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <NewAppScreen templateFileName="App.tsx" />
+      <HomeScreen />
     </View>
   );
 }

--- a/apps/mobile/__tests__/App.test.tsx
+++ b/apps/mobile/__tests__/App.test.tsx
@@ -3,11 +3,17 @@
  */
 
 import React from 'react';
-import ReactTestRenderer from 'react-test-renderer';
+import ReactTestRenderer, { act } from 'react-test-renderer';
+import { Text } from 'react-native';
 import App from '../App';
 
-test('renders correctly', async () => {
-  await ReactTestRenderer.act(() => {
-    ReactTestRenderer.create(<App />);
+test('renders home screen with cards', async () => {
+  let root;
+  await act(async () => {
+    root = ReactTestRenderer.create(<App />);
   });
+  const headingNodes = root.root.findAll(
+    (node) => node.type === Text && node.props.children === 'Heading 1',
+  );
+  expect(headingNodes.length).toBe(1);
 });

--- a/apps/mobile/components/Button.tsx
+++ b/apps/mobile/components/Button.tsx
@@ -1,0 +1,22 @@
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+
+export default function Button({ label, onPress }: { label: string; onPress: () => void }) {
+  return (
+    <TouchableOpacity style={styles.button} onPress={onPress}>
+      <Text style={styles.label}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: '#3b82f6',
+    paddingVertical: 12,
+    borderRadius: 9999,
+    alignItems: 'center',
+  },
+  label: {
+    color: '#fff',
+    fontWeight: 'bold',
+  },
+});

--- a/apps/mobile/components/Card.tsx
+++ b/apps/mobile/components/Card.tsx
@@ -1,0 +1,70 @@
+import { View, Text, Image, StyleSheet } from 'react-native';
+import Button from './Button';
+import type { CardData } from '../data/cards';
+
+export default function Card({
+  data,
+  isSelected,
+  onPress,
+}: {
+  data: CardData;
+  isSelected: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <View style={[styles.card, isSelected && styles.selected]}>
+      <Image source={data.img} style={styles.image} />
+      <View style={styles.body}>
+        <Text style={styles.heading}>{data.heading}</Text>
+        {data.sub ? <Text style={styles.sub}>{data.sub}</Text> : null}
+        {data.body.map((p, i) => (
+          <Text key={i} style={styles.text}>
+            {p}
+          </Text>
+        ))}
+      </View>
+      <View style={styles.buttonContainer}>
+        <Button label={data.cta} onPress={onPress} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    overflow: 'hidden',
+    backgroundColor: '#fff',
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+  },
+  selected: {
+    borderColor: '#3b82f6',
+    borderWidth: 4,
+  },
+  image: {
+    width: '100%',
+    height: 192,
+  },
+  body: {
+    padding: 16,
+  },
+  heading: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 8,
+  },
+  sub: {
+    color: '#3b82f6',
+    marginBottom: 8,
+  },
+  text: {
+    fontSize: 14,
+    marginBottom: 8,
+  },
+  buttonContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+});

--- a/apps/mobile/data/cards.ts
+++ b/apps/mobile/data/cards.ts
@@ -1,0 +1,46 @@
+import { ImageSourcePropType } from 'react-native';
+
+export interface CardData {
+  id: number;
+  heading: string;
+  sub?: string;
+  body: string[];
+  img: ImageSourcePropType;
+  cta: string;
+}
+
+const placeholder = { uri: 'https://via.placeholder.com/400x300.png?text=Banner' };
+
+export const cards: CardData[] = [
+  {
+    id: 1,
+    heading: 'Heading 1',
+    sub: 'Subtitle 1',
+    body: [
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
+    ],
+    img: placeholder,
+    cta: 'Button 1',
+  },
+  {
+    id: 2,
+    heading: 'Heading 2',
+    sub: 'Subtitle 2',
+    body: [
+      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.',
+    ],
+    img: placeholder,
+    cta: 'Button 2',
+  },
+  {
+    id: 3,
+    heading: 'Heading 3',
+    sub: 'Subtitle 3',
+    body: [
+      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
+      'Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.',
+    ],
+    img: placeholder,
+    cta: 'Button 3',
+  },
+];

--- a/apps/mobile/screens/HomeScreen.tsx
+++ b/apps/mobile/screens/HomeScreen.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+import { SafeAreaView, FlatList, StyleSheet } from 'react-native';
+import Card from '../components/Card';
+import type { CardData } from '../data/cards';
+import { cards } from '../data/cards';
+
+export default function HomeScreen() {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <FlatList<CardData>
+        data={cards}
+        keyExtractor={(item) => item.id.toString()}
+        renderItem={({ item }) => (
+          <Card
+            data={item}
+            isSelected={item.id === selectedId}
+            onPress={() => setSelectedId(item.id)}
+          />
+        )}
+        contentContainerStyle={styles.listContent}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  listContent: {
+    padding: 16,
+  },
+});


### PR DESCRIPTION
## Summary
- add simple card-based HomeScreen for React Native app
- replace template screen with new HomeScreen
- add test covering card rendering

## Testing
- `npm -w mobile test`


------
https://chatgpt.com/codex/tasks/task_e_6899fda28534832c912e5743b3f26036