### PR TITLE
feat: add shared React Native components

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,27 +1,44 @@
-/**
- * Sample React Native App
- * https://github.com/facebook/react-native
- *
- * @format
- */
+import React, {useState} from 'react';
+import {SafeAreaView, ScrollView, StatusBar, StyleSheet, useColorScheme} from 'react-native';
+import {Card, CardData} from '@dealer/shared';
 
-import { NewAppScreen } from '@react-native/new-app-screen';
-import { StatusBar, StyleSheet, useColorScheme, View } from 'react-native';
+const sample: CardData[] = [
+  {
+    id: 1,
+    heading: 'Welcome',
+    body: ['This card is rendered with shared components.'],
+    img: 'https://placehold.co/600x400',
+    cta: 'Select',
+  },
+];
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
+  const [selected, setSelected] = useState<number | null>(null);
 
   return (
-    <View style={styles.container}>
+    <SafeAreaView style={styles.container}>
       <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <NewAppScreen templateFileName="App.tsx" />
-    </View>
+      <ScrollView contentContainerStyle={styles.content}>
+        {sample.map(item => (
+          <Card
+            key={item.id}
+            data={item}
+            selected={selected === item.id}
+            onSelect={setSelected}
+          />
+        ))}
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  content: {
+    padding: 16,
   },
 });
 

--- a/packages/shared/src/components/Button.tsx
+++ b/packages/shared/src/components/Button.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import {TouchableOpacity, Text, StyleSheet, GestureResponderEvent} from 'react-native';
+
+interface ButtonProps {
+  label: string;
+  onPress: (event: GestureResponderEvent) => void;
+}
+
+export default function Button({label, onPress}: ButtonProps) {
+  return (
+    <TouchableOpacity style={styles.button} onPress={onPress}>
+      <Text style={styles.label}>{label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    width: '100%',
+    paddingVertical: 12,
+    borderRadius: 9999,
+    backgroundColor: '#2563eb',
+    alignItems: 'center',
+  },
+  label: {
+    color: '#ffffff',
+    fontWeight: '700',
+    fontSize: 16,
+  },
+});

--- a/packages/shared/src/components/Card.tsx
+++ b/packages/shared/src/components/Card.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import {View, Text, Image, StyleSheet, ViewStyle} from 'react-native';
+import Button from './Button';
+
+export interface CardData {
+  id: number;
+  heading: string;
+  body: string[];
+  img: string;
+  cta: string;
+  sub?: string;
+}
+
+interface CardProps {
+  data: CardData;
+  onSelect: (id: number) => void;
+  selected?: boolean;
+  style?: ViewStyle;
+}
+
+export default function Card({data, onSelect, selected = false, style}: CardProps) {
+  return (
+    <View style={[styles.card, selected && styles.selected, style]}>
+      <Image source={{uri: data.img}} style={styles.image} />
+      <View style={styles.body}>
+        <Text style={styles.heading}>{data.heading}</Text>
+        {data.sub && <Text style={styles.sub}>{data.sub}</Text>}
+        {data.body.map((p, i) => (
+          <Text key={i} style={styles.paragraph}>
+            {p}
+          </Text>
+        ))}
+      </View>
+      <View style={styles.buttonContainer}>
+        <Button label={data.cta} onPress={() => onSelect(data.id)} />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#ffffff',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+    overflow: 'hidden',
+    marginBottom: 8,
+    alignSelf: 'center',
+    maxWidth: 384,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+  selected: {
+    borderColor: '#3b82f6',
+    borderWidth: 4,
+  },
+  image: {
+    width: '100%',
+    height: 192,
+  },
+  body: {
+    padding: 16,
+    flex: 1,
+  },
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: '#111827',
+  },
+  sub: {
+    fontSize: 12,
+    color: '#2563eb',
+    marginBottom: 8,
+  },
+  paragraph: {
+    fontSize: 14,
+    color: '#374151',
+    marginBottom: 12,
+  },
+  buttonContainer: {
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+    marginTop: 'auto',
+  },
+});

--- a/packages/shared/src/components/index.ts
+++ b/packages/shared/src/components/index.ts
@@ -1,0 +1,3 @@
+export {default as Button} from './Button';
+export {default as Card} from './Card';
+export type {CardData} from './Card';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
-export * from "./demo";
-export const SHARED_VERSION = "0.1.0";
+export * from './demo';
+export * from './components';
+export const SHARED_VERSION = '0.1.0';


### PR DESCRIPTION
## Summary
- add `Button` and `Card` components using React Native primitives to shared package
- export shared components for reuse across apps and showcase usage in mobile app

## Testing
- `npm run typecheck` *(fails: Cannot read file '/workspace/mobile_app/tsconfig.json')*
- `npm -w mobile run lint`
- `npm -w mobile test`

------
https://chatgpt.com/codex/tasks/task_e_6899feaa89cc832cb2a4a823a6e2d53f