### PR TITLE
fix: ensure React Native privacy manifest exists

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -8,13 +8,14 @@
     "ios": "react-native run-ios",
     "lint": "eslint .",
     "start": "react-native start",
-    "test": "jest"
+    "test": "jest",
+    "postinstall": "node scripts/addPrivacyManifest.js"
   },
   "dependencies": {
     "react": "19.1.0",
     "react-native": "0.80.2",
     "@react-native/new-app-screen": "0.80.2",
-     "@dealer/shared": "0.1.0"
+    "@dealer/shared": "0.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/apps/mobile/scripts/addPrivacyManifest.js
+++ b/apps/mobile/scripts/addPrivacyManifest.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const manifestPath = path.join(__dirname, '..', 'node_modules', 'react-native', 'ReactCommon', 'cxxreact', 'PrivacyInfo.xcprivacy');
+
+if (!fs.existsSync(manifestPath)) {
+  const content = `<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict/>\n</plist>\n`;
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
+  fs.writeFileSync(manifestPath, content, 'utf8');
+  console.log('Created React Native PrivacyInfo.xcprivacy');
+} else {
+  console.log('React Native PrivacyInfo.xcprivacy already exists');
+}


### PR DESCRIPTION
## Summary
- generate missing React Native PrivacyInfo.xcprivacy during install
- run script automatically after installing mobile workspace

## Testing
- `npm -w mobile test` *(fails: jest: not found)*
- `npm -w mobile run ios` *(fails: react-native: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0a11ca90832c99f6ddb5b8e93e55