### PR TITLE
fix: correct gradle plugin path for mobile android build

### DIFF
--- a/apps/mobile/android/settings.gradle
+++ b/apps/mobile/android/settings.gradle
@@ -1,6 +1,6 @@
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
+pluginManagement { includeBuild("../../../node_modules/@react-native/gradle-plugin") }
 plugins { id("com.facebook.react.settings") }
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'MobileApp'
 include ':app'
-includeBuild('../node_modules/@react-native/gradle-plugin')
+includeBuild('../../../node_modules/@react-native/gradle-plugin')


### PR DESCRIPTION
## Summary
- fix gradle plugin path to root node_modules in mobile app settings.gradle

## Testing
- `npm -w mobile test` *(fails: sh: 1: jest: not found)*
- `npm -w mobile run android` *(fails: sh: 1: react-native: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a0aa84cd0832c8095e3f2dc629704